### PR TITLE
✨  Add optional flag to avoid loading timers from file system

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP32Timers",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A simple timer library that can save its state to a file on teardown. It is also protected against a wraparound of the millis() function.",
   "keywords": "timing, timer, millis, wraparound, save, state",
   "repository": {

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP32Timers",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A simple timer library that can save its state to a file on teardown. It is also protected against a wraparound of the millis() function.",
   "keywords": "timing, timer, millis, wraparound, save, state",
   "repository": {

--- a/src/Timers.cpp
+++ b/src/Timers.cpp
@@ -1,7 +1,9 @@
 #include "Timers.h"
 
 namespace Timers {
-Timers::Timers(fs::FS &fs, const char *filename) : _fs(fs), _filename(filename) { load(); }
+Timers::Timers(fs::FS &fs, const char *filename, bool load) : _fs(fs), _filename(filename) {
+    if (load) load();
+}
 
 Timers::~Timers() {
     save();

--- a/src/Timers.h
+++ b/src/Timers.h
@@ -66,12 +66,12 @@ class Timers {
 
     uint32_t getRemainingTime(const String &name);
 
-   private:
     /**
      * @brief Loads the timers from the file system.
      */
     void load();
 
+   private:
     /**
      * @brief Saves the timers to the file system.
      */

--- a/src/Timers.h
+++ b/src/Timers.h
@@ -21,8 +21,10 @@ class Timers {
      * of file systems are SPIFFS, SD_MMC and LittleFS.
      * @param filename The name of the file to load and save timers. This could
      * also be a path if the file system supports it.
+     * @param load If true, the timers are loaded from the file system. This
+     * crashes if the filesystem is not mounted.
      */
-    Timers(fs::FS &fs, const char *filename);
+    Timers(fs::FS &fs, const char *filename, bool load = true);
 
     /**
      * @brief Destroys the Timers object.


### PR DESCRIPTION
If you initialise this class at a global level before, you would run into a crash caused by the uninitialised file system.